### PR TITLE
Timeone modification for Turkey (Istanbul)

### DIFF
--- a/data/static.php
+++ b/data/static.php
@@ -75,11 +75,11 @@
 		array('(UTC+02:00) Gaza, Hebron',					'Asia/Gaza',			false,	'Eastern European Time',		'Eastern European Summer Time'),
 		array('(UTC+02:00) Harare, Pretoria',					'Africa/Harare',		false,	'Central Africa Time',			null),
 		array('(UTC+02:00) Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius',	'Europe/Helsinki',		false,	'Eastern European Time',		'Eastern European Summer Time'),
-		array('(UTC+02:00) Istanbul',						'Asia/Istanbul',		false,	'Eastern European Time',		'Eastern European Summer Time'),
 		array('(UTC+02:00) Jerusalem',						'Asia/Jerusalem',		false,	'Israel Standard Time',			'Israel Daylight Time'),
 		array('(UTC+02:00) Kaliningrad',					'Europe/Kaliningrad',		false,	'Eastern European Time',		null), # RTZ1
 		array('(UTC+02:00) Tripoli',						'Africa/Tripoli',		false,	'Eastern European Time',		null),
 		array('(UTC+03:00) Baghdad',						'Asia/Baghdad',			false,	'Arabia Standard Time',			null),
+		array('(UTC+03:00) Istanbul',						'Asia/Istanbul',		false,	'Eastern European Time',		null),
 		array('(UTC+03:00) Kuwait, Riyadh',					'Asia/Kuwait',			true,	'Arabia Standard Time',			null),
 		array('(UTC+03:00) Minsk',						'Europe/Minsk',			false,	'Further-eastern European Time',	null),
 		array('(UTC+03:00) Moscow, St. Petersburg, Volgograd',			'Europe/Moscow',		true,	'Moscow Time',				null), # RTZ2


### PR DESCRIPTION
 - Changed to UTC +3
 - No longer on Eastern European Summer Time